### PR TITLE
Check if content is empty to return empty []byte

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -17,14 +17,19 @@ func embedTemplate() string {
 		"\n" +
 		"package {{.Package}}\n" +
 		"\n" +
+		"\t{{ if not .EmptyContent }} " +
 		"import \"encoding/base64\"\n" +
+		"{{ end }}\n" +
 		"\n" +
 		"// {{.Name}}Resource is a generated function returning the Resource as a []byte.\n" +
 		"func {{.Name}}Resource() ([]byte, error) {\n" +
 		"\tvar resource = \"{{.Content}}\"\n" +
 		"\n" +
-		"\treturn base64.StdEncoding.DecodeString(resource)\n" +
-		"}\n" +
-		""
+		"\treturn {{ if .EmptyContent }} " +
+		"[]byte(resource), nil" +
+		"{{ else }}" +
+		"base64.StdEncoding.DecodeString(resource)" +
+		"{{ end }}\n" +
+		"}\n" + ""
 	return tmpl
 }

--- a/embed.tpl
+++ b/embed.tpl
@@ -6,11 +6,12 @@
 
 package {{.Package}}
 
-import "encoding/base64"
+	{{ if not .EmptyContent }} import "encoding/base64"
+{{ end }}
 
 // {{.Name}}Resource is a generated function returning the Resource as a []byte.
 func {{.Name}}Resource() ([]byte, error) {
 	var resource = "{{.Content}}"
 
-	return base64.StdEncoding.DecodeString(resource)
+	return {{ if .EmptyContent }} []byte(resource), nil{{ else }}base64.StdEncoding.DecodeString(resource){{ end }}
 }

--- a/mule.go
+++ b/mule.go
@@ -185,9 +185,10 @@ func main() {
 	}
 
 	data := struct {
-		Package string
-		Name    string
-		Content string
+		Package      string
+		Name         string
+		Content      string
+		EmptyContent bool
 	}{
 		Package: pckg,
 		Name:    strings.Split(functionname, ".")[0],
@@ -196,6 +197,10 @@ func main() {
 	if err != nil {
 		fmt.Printf("Error reading target resource file file '%s'\n%v\n", inputfile, err)
 		os.Exit(1)
+	}
+
+	if len(data.Content) == 0 {
+		data.EmptyContent = true
 	}
 
 	outfile, err := os.Create(outfilename)


### PR DESCRIPTION
If the content is an empty file, then return `[]byte(resource)` instead the error decoding from `base64` an empty string.